### PR TITLE
Add linebreak rule to base eslint config

### DIFF
--- a/eslint-config-itrex-base/index.js
+++ b/eslint-config-itrex-base/index.js
@@ -11,5 +11,6 @@ module.exports = {
       'global-require': 0,
       'arrow-parens': 0,
       'semi': 0,
+      "linebreak-style": 0,
     }
 };


### PR DESCRIPTION
Added rule fix error, which appears, when developers use different OS like Windows and Unix